### PR TITLE
Bug Fix - API Configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 # api redirect
 [[redirects]]
   from = "/api/*"
-  to = "https://rymostoreapi.herokuapp.com/api/:splat"
+  to = "https://rymostore.onrender.com/api/:splat"
   status = 200
   force = true
 # SPA router


### PR DESCRIPTION
Updated the API redirect configuration in `netlify.toml` from Heroku to current service hosted with Render.